### PR TITLE
Add dummy TikTok-style website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TikTok Dummy</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="feed">
+    <div class="video-container">
+      <video src="https://www.w3schools.com/html/mov_bbb.mp4" loop muted playsinline></video>
+      <div class="video-info">
+        <h3>@nature</h3>
+        <p>Soothing waterfall</p>
+      </div>
+      <div class="sidebar">
+        <div class="icon">❤️</div>
+        <div class="icon">💬</div>
+        <div class="icon">↗️</div>
+      </div>
+    </div>
+    <div class="video-container">
+      <video src="https://www.w3schools.com/html/movie.mp4" loop muted playsinline></video>
+      <div class="video-info">
+        <h3>@city</h3>
+        <p>Night lights</p>
+      </div>
+      <div class="sidebar">
+        <div class="icon">❤️</div>
+        <div class="icon">💬</div>
+        <div class="icon">↗️</div>
+      </div>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const videos = document.querySelectorAll('video');
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.play();
+      } else {
+        entry.target.pause();
+      }
+    });
+  }, { threshold: 0.6 });
+
+  videos.forEach(video => observer.observe(video));
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,43 @@
+body, html {
+  margin: 0;
+  padding: 0;
+  background: #000;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  overflow-x: hidden;
+}
+
+.feed {
+  height: 100vh;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.video-container {
+  position: relative;
+  height: 100vh;
+  scroll-snap-align: start;
+}
+
+video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sidebar {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  font-size: 24px;
+}
+
+.video-info {
+  position: absolute;
+  bottom: 60px;
+  left: 10px;
+}


### PR DESCRIPTION
## Summary
- add a static HTML page with two sample videos and basic TikTok-style layout
- style page with full-screen snap scrolling and sidebar actions
- autoplay videos in view using IntersectionObserver

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68903ae19d90833095b38ee3ccd0faa4